### PR TITLE
Security: Do not use `sudo` for `git`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ Basic usage doesn't require any installation, but if you wish to import the
 `judges.json` file into a Python program, you may want to install this as a
 Python module in your system. To do so:
 
-    sudo git clone https://github.com/freelawproject/judge-pics
-    python setup.py install
+    git clone https://github.com/freelawproject/judge-pics
+    sudo python setup.py install
 
 You can then import the `judges.json` information into your project using:
 


### PR DESCRIPTION
I infer that the `sudo` invocation was intended for the following line, which installs a Python module; I have not tested this.

I find it useful to copy and paste tested commands from the terminal, or from shell history.

(N.b. that my commit eeb9027 is signed, per `git log --show-signature`; Github’s verification evidently has a bug.)