### PR TITLE
fix(github): Remove duplicate funding file

### DIFF
--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,4 +1,0 @@
-# These are supported funding model platforms
-
-github: freelawproject
-custom: https://www.courtlistener.com/donate/?referrer=github-courtlistener


### PR DESCRIPTION
When I cloned this repository, Git warned about a file collision:

```
$ gh repo clone freelawproject/judge-pics
Cloning into 'judge-pics'...
...
warning: the following paths have collided (e.g. case-sensitive paths
on a case-insensitive filesystem) and only one from the same
colliding group is in the working tree:

  '.github/FUNDING.yml'
  '.github/funding.yml'
```

This collision occurs because Git allows tracking filenames with differing case, but my disk (macOS APFS) is case-insensitive. Git reported that it could only create one of them.

I checked the file contents and they were thankfully identical:

```
$ git show @:./funding.yml
# These are supported funding model platforms

github: freelawproject
custom: https://www.courtlistener.com/donate/?referrer=github-courtlistener
```

```
$ git show @:./FUNDING.yml
# These are supported funding model platforms

github: freelawproject
custom: https://www.courtlistener.com/donate/?referrer=github-courtlistener
```

I checked the [relevant GitHub documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository) and uppercase `FUNDING.yml` is the supported filename, so this PR removes the lowercase version.