### PR TITLE
chore(ci): Remove checkout arguments

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -10,9 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-         format: space-delimited
-         token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install stuff
         run: |
           sudo apt-get update


### PR DESCRIPTION
These arguments being passed to `actions/checkout` don't do anything, so they can be removed. They blame back to the reset commit, ab5649c.