### PR TITLE
chore(docker): Remove apt-get Retries option

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,6 @@ jobs:
     - name: Install OS dependencies
       run: |
         sudo apt-get install \
-                --option "Acquire::Retries=3" \
                 --no-install-recommends \
                 --assume-yes \
                 --quiet=2 \


### PR DESCRIPTION
The default was changed to 3 in apt 2.3.2 (2021): https://salsa.debian.org/apt-team/apt/-/blob/main/debian/changelog\#L1708-1711